### PR TITLE
template UTF8 input coding, removed extra double quote

### DIFF
--- a/ViewEngineTool.ps1
+++ b/ViewEngineTool.ps1
@@ -5,8 +5,8 @@ function RenderViewNativePowerShell(
 )
 {
 	$viewFileName = Resolve-Path ('Views\' + $viewName)
-	$templateContent = Get-Content $viewFileName | Out-String
-	return $ExecutionContext.InvokeCommand.ExpandString('"' + $templateContent + '"')
+	$templateContent = Get-Content $viewFileName -encoding UTF8 | Out-String
+	return $ExecutionContext.InvokeCommand.ExpandString($templateContent)
 }
 
 function RenderView(


### PR DESCRIPTION
Most useful, thanks.
quick fix :

 - template UTF8 input coding (for € char), and 
 - NativePS render without extra dblquote, for integration